### PR TITLE
Allow specifying versions (or HEAD) of formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ The only platform supported by Homebrew itself at the time of this writing is Ma
 - `node['homebrew']['owner']` - The user that will own the Homebrew installation and packages. Setting this will override the default behavior which is to use the non-privileged user that has invoked the Chef run (or the `SUDO_USER` if invoked with sudo). The default is `nil`.
 - `node['homebrew']['auto-update']` - Whether the default recipe should automatically update homebrew each run or not. The default is `true` to maintain compatibility. Set to false or nil to disable. Note that disabling this feature may cause formula to not work.
 - `node['homebrew']['formulas']` - An Array of formula that should be installed using homebrew by default, used only in the `homebrew::install_formulas` recipe.
+  - To install the most recent version, include just the recipe name: `- simple_formula`
+  - To install a specific version, specify both its name and version:
+
+    ```
+    - name: special-version-formula
+      version: 1.2.3
+    ```
+  - To install the HEAD of a formula, specify both its name and `head: true`:
+
+    ```
+    - name: head-tracking-formula
+      head: true
+    ```
 - `node['homebrew']['casks']` - An Array of casks that should be installed using brew cask by default, used only in the `homebrew::install_casks` recipe.
 - `node['homebrew']['taps']` - An Array of taps that should be installed using brew tap by default, used only in the `homebrew::install_taps` recipe.
 

--- a/recipes/install_formulas.rb
+++ b/recipes/install_formulas.rb
@@ -22,6 +22,7 @@ include_recipe 'homebrew'
 node['homebrew']['formulas'].each do |formula|
   if formula.class == Chef::Node::ImmutableMash
     package formula.fetch(:name) do
+      options '--HEAD' if formula.fetch(:head, false)
       version formula['version'] if formula.fetch(:version, false)
     end
   else

--- a/recipes/install_formulas.rb
+++ b/recipes/install_formulas.rb
@@ -20,5 +20,11 @@
 include_recipe 'homebrew'
 
 node['homebrew']['formulas'].each do |formula|
-  package formula
+  if formula.class == Chef::Node::ImmutableMash
+    package formula.fetch(:name) do
+      version formula['version'] if formula.fetch(:version, false)
+    end
+  else
+    package formula
+  end
 end

--- a/spec/recipes/install_formulas_spec.rb
+++ b/spec/recipes/install_formulas_spec.rb
@@ -31,4 +31,16 @@ describe 'homebrew::install_formulas' do
       expect(chef_run).to install_package('pstree').with(version: '9.9.9')
     end
   end
+
+  context 'requesting a HEAD version' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['homebrew']['formulas'] = [{ name: 'pstree', head: true }]
+      end.converge(described_recipe)
+    end
+
+    it 'package-installs the HEAD of the formula' do
+      expect(chef_run).to install_package('pstree').with(options: '--HEAD')
+    end
+  end
 end

--- a/spec/recipes/install_formulas_spec.rb
+++ b/spec/recipes/install_formulas_spec.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe 'homebrew::install_formulas' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set['homebrew']['formulas'] = %w(pstree wget)
+    end.converge(described_recipe)
+  end
+
+  before do
+    stub_command('which git').and_return('/usr/local/bin/git')
+  end
+
+  it 'installs homebrew' do
+    expect(chef_run).to include_recipe('homebrew')
+  end
+
+  it 'package-installs each recipe' do
+    expect(chef_run).to install_package('pstree')
+    expect(chef_run).to install_package('wget')
+  end
+end

--- a/spec/recipes/install_formulas_spec.rb
+++ b/spec/recipes/install_formulas_spec.rb
@@ -19,4 +19,16 @@ describe 'homebrew::install_formulas' do
     expect(chef_run).to install_package('pstree')
     expect(chef_run).to install_package('wget')
   end
+
+  context 'requesting a specific version' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['homebrew']['formulas'] = [{ name: 'pstree', version: '9.9.9' }]
+      end.converge(described_recipe)
+    end
+
+    it 'package-installs the requested version' do
+      expect(chef_run).to install_package('pstree').with(version: '9.9.9')
+    end
+  end
 end


### PR DESCRIPTION
It is sometimes necessary to install a specific version of a formula, or to install from the HEAD ref. Currently, it is only possible to specify recipes by name with no other option. This PR supports the following options:

```
homebrew:
  formulas:
    - simple-formula
    - name: special-version-formula
      version: 1.2.3
    - name: head-tracking-formula
      head: true
```