### PR TITLE
Fix Travis build by stubbing Chef12HomebrewUser#find_homebrew_id

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ rvm:
   - 2.1
   - 2.2
 script:
-  - bundle exec foodcritic -f any .
+  - bundle exec foodcritic -f any . -X spec
   - bundle exec rubocop
   - bundle exec rspec --color --format progress

--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -15,20 +15,18 @@ def load_current_resource
 end
 
 action :install do
-  unless @cask.casked
-    execute "installing cask #{new_resource.name}" do
-      command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
-      user homebrew_owner
-    end
+  execute "installing cask #{new_resource.name}" do
+    command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
+    user homebrew_owner
+    not_if { @cask.casked }
   end
 end
 
 action :uninstall do
-  if @cask.casked
-    execute "uninstalling cask #{new_resource.name}" do
-      command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
-      user homebrew_owner
-    end
+  execute "uninstalling cask #{new_resource.name}" do
+    command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
+    user homebrew_owner
+    only_if { @cask.casked }
   end
 end
 

--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -40,6 +40,8 @@ action :tap do
       not_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end
+
+    new_resource.updated_by_last_action(true)
   end
 end
 
@@ -50,5 +52,7 @@ action :untap do
       only_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end
+
+    new_resource.updated_by_last_action(true)
   end
 end

--- a/resources/tap.rb
+++ b/resources/tap.rb
@@ -23,7 +23,7 @@ actions :tap, :untap
 attribute :name,
           name_attribute: true,
           kind_of: String,
-          regex: /^[\w-]+(?:\/[\w-]+)+$/
+          regex: %r{^[\w-]+(?:\/[\w-]+)+$}
 
 attribute :tapped,
           kind_of: [TrueClass, FalseClass]

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -34,6 +34,7 @@ describe 'homebrew::default' do
     before(:each) do
       allow(File).to receive(:exist?).and_return(true)
       stub_command('which git').and_return(true)
+      allow_any_instance_of(Chef12HomebrewUser).to receive(:find_homebrew_uid).and_return(Process.uid)
     end
 
     it 'does not run homebrew installation' do


### PR DESCRIPTION
The Travis build is running on a Linux VM, which does not have Homebrew. When trying to figure out the Homebrew user, Chef12HomebrewUser requires Homebrew to be installed, so the method fails. Stubbing it with the current user's id allows the test to pass.

An alternate workaround is to modify .travis.yml to specify objective-c as the language, which will cause Travis to run specs in an OS X VM with Homebrew pre-installed.

This also includes a commit that address the Foodcritic warnings.