### PR TITLE
Stop already-installed casks breaking builds

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -37,7 +37,7 @@ action :install do
   execute "installing cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
     user homebrew_owner
-    not_if { @cask.casked }
+    not_if { new_resource.casked }
   end
 end
 
@@ -45,7 +45,7 @@ action :uninstall do
   execute "uninstalling cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
     user homebrew_owner
-    only_if { @cask.casked }
+    only_if { new_resource.casked }
   end
 end
 


### PR DESCRIPTION
@cask doesn't appear to be initialised in the `execute` block, and the
rest of the block seems to use `new_resource`, so use that.

Fixes chef-cookbooks/homebrew#78.

<ins>Obvious fix.</ins>