### PR TITLE
Fixes Cask provider casked check

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -27,17 +27,11 @@ def whyrun_supported?
   true
 end
 
-def load_current_resource
-  @cask = Chef::Resource::HomebrewCask.new(new_resource.name)
-  Chef::Log.debug("Checking whether #{new_resource.name} is installed")
-  @cask.casked shell_out("/usr/local/bin/brew cask list | grep #{new_resource.name}").exitstatus == 0
-end
-
 action :install do
   execute "installing cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
     user homebrew_owner
-    not_if { new_resource.casked }
+    not_if { new_resource.casked? }
   end
 end
 
@@ -45,7 +39,7 @@ action :uninstall do
   execute "uninstalling cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
     user homebrew_owner
-    only_if { new_resource.casked }
+    only_if { new_resource.casked? }
   end
 end
 

--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -6,8 +6,9 @@ attribute :name,
   kind_of: String,
   regex: /^[\w-]+$/
 
-attribute :casked,
-  kind_of: [TrueClass, FalseClass]
-
 attribute :options,
   kind_of: String
+
+def casked?
+  shell_out("/usr/local/bin/brew cask list | grep #{name}").exitstatus == 0
+end


### PR DESCRIPTION
Currently the cask provider will install the given cask on every run. This is caused because the casked check is currently broken. The `load_current_resource` method would mark the `@cask` object as casked when a cask already is installed. Since this object is never used it caused the the cask provider to install the cask on every run.

This adds a `Cask#casked?` method which uses the existing check.