### PR TITLE
More-resiliently create /opt/homebrew-cask

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -29,7 +29,7 @@ action :install do
   execute "installing cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
     user homebrew_owner
-    environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
+    environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
     not_if { new_resource.casked? }
   end
 end
@@ -38,7 +38,7 @@ action :uninstall do
   execute "uninstalling cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
     user homebrew_owner
-    environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
+    environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
     only_if { new_resource.casked? }
   end
 end

--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-require 'chef/mixin/shell_out'
-include Chef::Mixin::ShellOut
 include ::Homebrew::Mixin
 
 use_inline_resources
@@ -31,6 +29,7 @@ action :install do
   execute "installing cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask install #{new_resource.name} #{new_resource.options}"
     user homebrew_owner
+    environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
     not_if { new_resource.casked? }
   end
 end
@@ -39,6 +38,7 @@ action :uninstall do
   execute "uninstalling cask #{new_resource.name}" do
     command "/usr/local/bin/brew cask uninstall #{new_resource.name}"
     user homebrew_owner
+    environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
     only_if { new_resource.casked? }
   end
 end

--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -39,7 +39,7 @@ action :tap do
   unless @tap.tapped
     execute "tapping #{new_resource.name}" do
       command "/usr/local/bin/brew tap #{new_resource.name}"
-      environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
+      environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
       not_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end
@@ -50,7 +50,7 @@ action :untap do
   if @tap.tapped
     execute "untapping #{new_resource.name}" do
       command "/usr/local/bin/brew untap #{new_resource.name}"
-      environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
+      environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
       only_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end

--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -39,6 +39,7 @@ action :tap do
   unless @tap.tapped
     execute "tapping #{new_resource.name}" do
       command "/usr/local/bin/brew tap #{new_resource.name}"
+      environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
       not_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end
@@ -49,6 +50,7 @@ action :untap do
   if @tap.tapped
     execute "untapping #{new_resource.name}" do
       command "/usr/local/bin/brew untap #{new_resource.name}"
+      environment ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner })
       only_if "/usr/local/bin/brew tap | grep #{new_resource.name}"
       user homebrew_owner
     end

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -29,6 +29,7 @@ end
 directory '/opt/homebrew-cask' do
   owner homebrew_owner
   mode 00775
+  recursive true
 end
 
 directory '/opt/homebrew-cask/Caskroom' do

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -20,12 +20,10 @@ Chef::Resource.send(:include, Homebrew::Mixin)
 
 homebrew_tap 'caskroom/cask'
 
-package 'brew-cask'
-
-execute 'update homebrew cask from github' do
-  user node['homebrew']['owner'] || homebrew_owner
-  command '/usr/local/bin/brew upgrade brew-cask && /usr/local/bin/brew cask cleanup || true'
-  only_if { node['homebrew']['auto-update'] }
+directory '/Library/Caches/Homebrew/Casks' do
+  owner homebrew_owner
+  mode 00775
+  only_if { ::Dir.exist?('/Library/Caches/Homebrew') }
 end
 
 directory '/opt/homebrew-cask' do

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -29,11 +29,11 @@ execute 'update homebrew cask from github' do
 end
 
 directory '/opt/homebrew-cask' do
-  owner node['homebrew']['owner'] || homebrew_owner
+  owner homebrew_owner
   mode 00775
 end
 
 directory '/opt/homebrew-cask/Caskroom' do
-  owner node['homebrew']['owner'] || homebrew_owner
+  owner homebrew_owner
   mode 00775
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,6 +23,7 @@ Chef::Resource.send(:include, Homebrew::Mixin)
 Chef::Recipe.send(:include, Homebrew::Mixin)
 
 homebrew_go = "#{Chef::Config[:file_cache_path]}/homebrew_go"
+userenv = { 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }
 
 Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 
@@ -33,6 +34,7 @@ end
 
 execute 'install homebrew' do
   command homebrew_go
+  environment (userenv)
   user homebrew_owner
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
@@ -43,6 +45,7 @@ if node['homebrew']['auto-update']
   end
 
   execute 'update homebrew from github' do
+    environment (userenv)
     user homebrew_owner
     command '/usr/local/bin/brew update || true'
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -33,7 +33,7 @@ end
 
 execute 'install homebrew' do
   command homebrew_go
-  user node['homebrew']['owner'] || homebrew_owner
+  user homebrew_owner
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,6 @@ Chef::Resource.send(:include, Homebrew::Mixin)
 Chef::Recipe.send(:include, Homebrew::Mixin)
 
 homebrew_go = "#{Chef::Config[:file_cache_path]}/homebrew_go"
-userenv = { 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }
 
 Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 
@@ -34,7 +33,7 @@ end
 
 execute 'install homebrew' do
   command homebrew_go
-  environment (userenv)
+  environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
   user homebrew_owner
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
@@ -45,7 +44,7 @@ if node['homebrew']['auto-update']
   end
 
   execute 'update homebrew from github' do
-    environment (userenv)
+    environment lazy { ({ 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner }) }
     user homebrew_owner
     command '/usr/local/bin/brew update || true'
   end

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -11,6 +11,11 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Cask Cache directory' do
+      allow(Dir).to receive(:exist?)
+        .and_call_original
+      allow(Dir).to receive(:exist?)
+        .with('/Library/Caches/Homebrew/Casks')
+        .and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'vagrant',
         mode: 00775
@@ -40,6 +45,11 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Cask Cache directory' do
+      allow(Dir).to receive(:exist?)
+        .and_call_original
+      allow(Dir).to receive(:exist?)
+        .with('/Library/Caches/Homebrew/Casks')
+        .and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'alaska',
         mode: 00775

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -11,11 +11,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Cask Cache directory' do
-      allow(Dir).to receive(:exist?)
-        .and_call_original
-      allow(Dir).to receive(:exist?)
-        .with('/Library/Caches/Homebrew/Casks')
-        .and_return(true)
+      allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'vagrant',
         mode: 00775
@@ -45,11 +41,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Cask Cache directory' do
-      allow(Dir).to receive(:exist?)
-        .and_call_original
-      allow(Dir).to receive(:exist?)
-        .with('/Library/Caches/Homebrew/Casks')
-        .and_return(true)
+      allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'alaska',
         mode: 00775

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -10,9 +10,10 @@ describe 'homebrew::cask' do
       allow_any_instance_of(Chef::Resource).to receive(:homebrew_owner).and_return('vagrant')
     end
 
-    it 'updates homebrew cask as vagrant' do
-      expect(chef_run).to run_execute('update homebrew cask from github').with(
-        user: 'vagrant'
+    it 'manages the Cask Cache directory' do
+      expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
+        user: 'vagrant',
+        mode: 00775
       )
     end
 
@@ -38,9 +39,10 @@ describe 'homebrew::cask' do
       end.converge(described_recipe)
     end
 
-    it 'updates homebrew cask as alaska' do
-      expect(chef_run).to run_execute('update homebrew cask from github').with(
-        user: 'alaska'
+    it 'manages the Cask Cache directory' do
+      expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
+        user: 'alaska',
+        mode: 00775
       )
     end
 

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -51,7 +51,8 @@ describe 'homebrew::cask' do
     it 'manages the homebrew-cask directory' do
       expect(chef_run).to create_directory('/opt/homebrew-cask').with(
         user: 'alaska',
-        mode: 00775
+        mode: 00775,
+        recursive: true,
       )
     end
 


### PR DESCRIPTION
This is a small fix on top of @bdwyertech's #86 that creates /opt/homebrew-cask recursively.