### PR TITLE
Use 0o for octal literals

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -22,17 +22,17 @@ homebrew_tap 'caskroom/cask'
 
 directory '/Library/Caches/Homebrew/Casks' do
   owner homebrew_owner
-  mode 00775
+  mode 0o0775
   only_if { ::Dir.exist?('/Library/Caches/Homebrew') }
 end
 
 directory '/opt/homebrew-cask' do
   owner homebrew_owner
-  mode 00775
+  mode 0o0775
   recursive true
 end
 
 directory '/opt/homebrew-cask/Caskroom' do
   owner homebrew_owner
-  mode 00775
+  mode 0o0775
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 remote_file homebrew_go do
   source node['homebrew']['installer']['url']
   checksum node['homebrew']['installer']['checksum'] unless node['homebrew']['installer']['checksum'].nil?
-  mode 00755
+  mode 0o0755
 end
 
 execute 'install homebrew' do

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -14,21 +14,21 @@ describe 'homebrew::cask' do
       allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'vagrant',
-        mode: 00775
+        mode: 0o0775
       )
     end
 
     it 'manages the homebrew-cask directory' do
       expect(chef_run).to create_directory('/opt/homebrew-cask').with(
         user: 'vagrant',
-        mode: 00775
+        mode: 0o0775
       )
     end
 
     it 'manages the Caskroom directory' do
       expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
         user: 'vagrant',
-        mode: 00775
+        mode: 0o0775
       )
     end
   end
@@ -44,14 +44,14 @@ describe 'homebrew::cask' do
       allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'alaska',
-        mode: 00775
+        mode: 0o0775
       )
     end
 
     it 'manages the homebrew-cask directory' do
       expect(chef_run).to create_directory('/opt/homebrew-cask').with(
         user: 'alaska',
-        mode: 00775,
+        mode: 0o0775,
         recursive: true
       )
     end
@@ -59,7 +59,7 @@ describe 'homebrew::cask' do
     it 'manages the Caskroom directory' do
       expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
         user: 'alaska',
-        mode: 00775
+        mode: 0o0775
       )
     end
   end


### PR DESCRIPTION
### Description

Fixes a Rubocop error regarding octal literals

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
  - There are some tests that will likely not pass, as they have not been passing on master.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD