### PR TITLE
Do not manage old Caskroom location

### DIFF
--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -30,6 +30,7 @@ directory '/opt/homebrew-cask' do
   owner homebrew_owner
   mode 00775
   recursive true
+  only_if { ::Dir.exist?('/opt/homebrew-cask') }
 end
 
 directory '/opt/homebrew-cask/Caskroom' do

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -1,6 +1,24 @@
 require_relative '../spec_helper'
 
 describe 'homebrew::cask' do
+  before(:each) do
+    allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(false)
+    allow(Dir).to receive(:exist?).with('/opt/homebrew-cask').and_return(false)
+    allow(Dir).to receive(:exist?).with('/opt/homebrew-cask/Caskroom').and_return(false)
+  end
+
+  context 'if no directories exist' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe)
+    end
+
+    it 'manages no directory' do
+      expect(chef_run).to_not create_directory('/Library/Caches/Homebrew/Casks')
+      expect(chef_run).to_not create_directory('/opt/homebrew-cask')
+      expect(chef_run).to_not create_directory('/opt/homebrew-cask/Caskroom')
+    end
+  end
+
   context 'default user' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.11.1').converge(described_recipe)
@@ -19,6 +37,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the homebrew-cask directory' do
+      allow(Dir).to receive(:exist?).with('/opt/homebrew-cask').and_return(true)
       expect(chef_run).to create_directory('/opt/homebrew-cask').with(
         user: 'vagrant',
         mode: 00775
@@ -26,6 +45,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Caskroom directory' do
+      allow(Dir).to receive(:exist?).with('/opt/homebrew-cask/Caskroom').and_return(true)
       expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
         user: 'vagrant',
         mode: 00775
@@ -49,6 +69,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the homebrew-cask directory' do
+      allow(Dir).to receive(:exist?).with('/opt/homebrew-cask').and_return(true)
       expect(chef_run).to create_directory('/opt/homebrew-cask').with(
         user: 'alaska',
         mode: 00775,
@@ -57,6 +78,7 @@ describe 'homebrew::cask' do
     end
 
     it 'manages the Caskroom directory' do
+      allow(Dir).to receive(:exist?).with('/opt/homebrew-cask/Caskroom').and_return(true)
       expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
         user: 'alaska',
         mode: 00775


### PR DESCRIPTION
### Description

Homebrew-Cask has changed the default Caskroom location (see
caskroom/homebrew-cask#21857). This cookbook
should no longer attempt to manage the legacy location
(/opt/homebrew-cask/Caskroom).

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
  - There are some tests that will likely not pass, as they have not been passing on master.
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [X] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
