### PR TITLE
Don't grab homebrew_go script if homebrew is already installed.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,6 +30,7 @@ remote_file homebrew_go do
   source node['homebrew']['installer']['url']
   checksum node['homebrew']['installer']['checksum'] unless node['homebrew']['installer']['checksum'].nil?
   mode 00755
+  not_if { ::File.exist? '/usr/local/bin/brew' }
 end
 
 execute 'install homebrew' do


### PR DESCRIPTION
### Description

Simply avoids downloading the homebrew_go install script from node['homebrew']['installer']['url'] if homebrew is already installed (and therefore the script would never be run).

### Issues Resolved

Unknown

I have an issue whereby homebrew managed to get installed on a box behind a firewall, but the firewall now blocks the default homebrew install script URL. Deploying my chef recipes for the box fail unnecessarily now since homebrew is already installed, but the remote_file call for the install script fails due to an SSL cert issue (which is really because the firewall is blocking the call).

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
