### PR TITLE
Add ability to disable sending analytics

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,5 +1,6 @@
 driver:
   name: vagrant
+  provider: vmware_fusion
 
 provisioner:
   name: chef_zero
@@ -8,11 +9,9 @@ platforms:
   - name: macosx-10.10
     driver:
       box: chef/macosx-10.10 # private box in Chef's Atlas account
-      provider: vmware_fusion
   - name: macosx-10.11
     driver:
       box: chef/macosx-10.11 # private box in Chef's Atlas account
-      provider: vmware_fusion
 
 suites:
   - name: default
@@ -31,3 +30,4 @@ suites:
           - caffeine
         taps:
           - homebrew/homebrew-games
+        enable-analytics: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -26,3 +26,4 @@ default['homebrew']['formulas'] = node['homebrew']['formula'] || []
 default['homebrew']['taps'] = []
 default['homebrew']['installer']['url'] = 'https://raw.githubusercontent.com/Homebrew/install/master/install'
 default['homebrew']['installer']['checksum'] = nil
+default['homebrew']['enable-analytics'] = true

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -22,6 +22,6 @@ homebrew_tap 'caskroom/cask'
 
 directory '/Library/Caches/Homebrew/Casks' do
   owner homebrew_owner
-  mode "775"
+  mode '775'
   only_if { ::Dir.exist?('/Library/Caches/Homebrew') }
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -40,6 +40,12 @@ execute 'install homebrew' do
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
 
+execute 'set analytics' do
+  environment lazy { { 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner } }
+  user homebrew_owner
+  command "/usr/local/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off' }"
+end
+
 if node['homebrew']['auto-update']
   package 'git' do
     not_if 'which git'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -29,7 +29,7 @@ Chef::Log.debug("Homebrew owner is '#{homebrew_owner}'")
 remote_file homebrew_go do
   source node['homebrew']['installer']['url']
   checksum node['homebrew']['installer']['checksum'] unless node['homebrew']['installer']['checksum'].nil?
-  mode "755"
+  mode '755'
   not_if { ::File.exist? '/usr/local/bin/brew' }
 end
 
@@ -43,7 +43,8 @@ end
 execute 'set analytics' do
   environment lazy { { 'HOME' => ::Dir.home(homebrew_owner), 'USER' => homebrew_owner } }
   user homebrew_owner
-  command "/usr/local/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off' }"
+  command "/usr/local/bin/brew analytics #{node['homebrew']['enable-analytics'] ? 'on' : 'off'}"
+  only_if { shell_out('/usr/local/bin/brew analytics state', user: homebrew_owner).stdout.include?('enabled') != node['homebrew']['enable-analytics'] }
 end
 
 if node['homebrew']['auto-update']

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -14,7 +14,7 @@ describe 'homebrew::cask' do
       allow(Dir).to receive(:exist?).with('/Library/Caches/Homebrew').and_return(true)
       expect(chef_run).to create_directory('/Library/Caches/Homebrew/Casks').with(
         user: 'vagrant',
-        mode: 00775
+        mode: '775'
       )
     end
   end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -62,6 +62,22 @@ describe 'homebrew::default' do
     end
   end
 
+  context 'disables brew analytics' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.10') do |node|
+        node.normal['homebrew']['enable-analytics'] = false
+      end.converge(described_recipe)
+    end
+
+    before(:each) do
+      stub_command('which git').and_return(true)
+    end
+
+    it 'turns off analytics' do
+      expect(chef_run).to_not run_execute('set analytics')
+    end
+  end
+
   context 'conditionally manage git package' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'mac_os_x', version: '10.10').converge(described_recipe)

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,24 +1,24 @@
 require 'spec_helper'
 
 describe 'homebrew installation' do
-  describe command('/usr/local/bin/brew info redis --json=v1') do
+  describe command('sudo -u vagrant /usr/local/bin/brew info redis --json=v1') do
     # the JSON output is awkward to parse here, but it's
     # cross-platform-version, since the formula may be installed as a
     # source or from bottle depending on the version of OS X.
     its(:stdout) { should match('"installed":\[{"version":') }
   end
 
-  describe command(%[chef-apply -l info -e 'Chef::Log.info(Chef::Platform.find(:mac_os_x, nil)[:package])']) do
+  describe command(%[chef-apply -e 'Chef::Log.info(Chef::Platform.find(:mac_os_x, nil)[:package]) -l info']) do
     its(:stdout) { should match('INFO: Chef::Provider::Package::Homebrew') }
   end
 
-  describe file('/opt/homebrew-cask/Caskroom/caffeine') do
+  describe file('/usr/local/Caskroom/caffeine') do
     it { should be_directory }
     it { should be_mode 755 }
     it { should be_owned_by 'vagrant' }
   end
 
-  describe file('/usr/local/Library/Taps/homebrew/homebrew-games/.git') do
+  describe file('/usr/local/Homebrew/Library/Taps/homebrew/homebrew-games/.git') do
     it { should be_directory }
     it { should be_owned_by 'vagrant' }
   end


### PR DESCRIPTION
Homebrew sends analytics, it does so by default with an opt-out strategy. This defaults to follow that strategy; however, allows for actually opting out after it's installed.

Signed-off-by: Brenton Bartel <brenton@letrabb.com>