### PR TITLE
Fixed issue with uninitialized constant Chef::Resource::HomebrewTap in Chef 13.0.118

### DIFF
--- a/providers/tap.rb
+++ b/providers/tap.rb
@@ -24,7 +24,7 @@ include ::Homebrew::Mixin
 use_inline_resources
 
 def load_current_resource
-  @tap = Chef::Resource::HomebrewTap.new(new_resource.name)
+  @tap = new_resource
   tap_dir = @tap.name.gsub('/', '/homebrew-')
 
   Chef::Log.debug("Checking whether we've already tapped #{new_resource.name}")


### PR DESCRIPTION
### Description

Fixes issue with cask resource on Chef 13.0.118
Changed how @tap variable is initialized by removing
`Chef::Resource::HomebrewTap.new`, which can't be resolved, to simply
`new_resource`, which resolves issue using Chef 13.0.118

### Issues Resolved
`
Error executing action `tap` on resource 'homebrew_tap[caskroom/cask]'`
**`uninitialized constant Chef::Resource::HomebrewTap`**

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
