### PR TITLE
Updates cask URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ end
 
 Resource for `brew cask`, a Homebrew-style CLI workflow for the administration of Mac applications distributed as binaries. It's implemented as a homebrew "external command" called cask.
 
-[homebrew-cask on GitHub](https://github.com/caskroom/homebrew-cask)
+[homebrew-cask on GitHub](https://github.com/Homebrew/homebrew-cask)
 
 #### Actions
 
@@ -107,7 +107,7 @@ homebrew_cask "Let's remove google-chrome" do
 end
 ```
 
-[View the list of available Casks](https://github.com/caskroom/homebrew-cask/tree/master/Casks)
+[View the list of available Casks](https://github.com/Homebrew/homebrew-cask/tree/master/Casks)
 
 ## Attributes
 

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-homebrew_tap 'caskroom/cask'
+homebrew_tap 'homebrew/cask'
 
 directory '/Library/Caches/Homebrew/Casks' do
   owner Homebrew.owner

--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -29,7 +29,7 @@ property :homebrew_path, String, default: '/usr/local/bin/brew'
 property :owner, String, default: lazy { Homebrew.owner } # lazy to prevent breaking compilation on non-macOS platforms
 
 action :install do
-  homebrew_tap 'caskroom/cask' if new_resource.install_cask
+  homebrew_tap 'homebrew/cask' if new_resource.install_cask
 
   unless casked?
     converge_by("install cask #{new_resource.name} #{new_resource.options}") do
@@ -42,7 +42,7 @@ action :install do
 end
 
 action :remove do
-  homebrew_tap 'caskroom/cask' if new_resource.install_cask
+  homebrew_tap 'homebrew/cask' if new_resource.install_cask
 
   if casked?
     converge_by("uninstall cask #{new_resource.name}") do


### PR DESCRIPTION
### Description

Homebrew cask was merged into homebrew some time ago: https://github.com/Homebrew/homebrew-cask/issues/14384#issuecomment-242328541.

Afterwards the homebrew-cask repositories were also moved to the Homebrew organization.

### Issues Resolved

Because of that move on Chef 13 and older with this cookbook installing a cask would try to tap `caskroom/cask` every time. If you execute that manually you'll notice that it actually taps `homebrew/cask`. 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>