### PR TITLE
Migrate default install script from ruby to bash

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,6 +24,6 @@ default['homebrew']['auto-update'] = true
 default['homebrew']['casks'] = []
 default['homebrew']['formulas'] = node['homebrew']['formula'] || []
 default['homebrew']['taps'] = []
-default['homebrew']['installer']['url'] = 'https://raw.githubusercontent.com/Homebrew/install/master/install'
+default['homebrew']['installer']['url'] = 'https://raw.githubusercontent.com/Homebrew/install/master/install.sh'
 default['homebrew']['installer']['checksum'] = nil
 default['homebrew']['enable-analytics'] = true


### PR DESCRIPTION
Closes issue #135.

Ruby Homebrew installer is now deprecated and should be migrated to Bash.

### Description

Install now works when using default values:

```ruby
include_recipe 'homebrew'
```

### Issues Resolved

Closes issue #135 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] ~~New functionality includes testing.~~
- [x] ~~New functionality has been documented in the README if applicable~~
- [x] Obvious Fix ~~All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>~~