### PR TITLE
brew cask list no longer supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the homebrew cookbook.
 
 - resolved cookstyle error: resources/cask.rb:23:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`
 - resolved cookstyle error: resources/tap.rb:23:1 warning: `ChefDeprecations/ResourceUsesOnlyResourceName`
+- resolved issues #145 - "brew cask list" no longer supported 
 
 ## 5.1.0 (2020-05-15)
 

--- a/resources/cask.rb
+++ b/resources/cask.rb
@@ -60,7 +60,7 @@ action_class do
 
   def casked?
     unscoped_name = new_resource.name.split('/').last
-    shell_out!("#{new_resource.homebrew_path} cask list 2>/dev/null",
+    shell_out!("#{new_resource.homebrew_path} list --cask 2>/dev/null",
       user: new_resource.owner,
       env: { 'HOME' => ::Dir.home(new_resource.owner), 'USER' => new_resource.owner },
       cwd: ::Dir.home(new_resource.owner)).stdout.split.include?(unscoped_name)


### PR DESCRIPTION
### Description
Fixes error `Calling brew cask list is disabled! Use brew list [--cask] instead`

### Issues Resolved
#145 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>